### PR TITLE
Update main.js

### DIFF
--- a/CosmoQuestBot-master/main.js
+++ b/CosmoQuestBot-master/main.js
@@ -79,9 +79,9 @@ const client = new Client({ intents: [Intents.FLAGS.GUILDS, Intents.FLAGS.GUILD_
         } catch (e) {
             e.fileName = file;
             log();
-            warn(new SyntaxError(`file ${file} was incorrectly setup`));
+            warn(e);
+            warn("SyntaxError:", `file ${file} was incorrectly setup so it was not loaded`);
             log();
-            process.exit();
         }})(file)
     }
 


### PR DESCRIPTION

## Description

Commands that throw errors on load no longer terminate the bot.

## Original

```js
try {
    // [...]
} catch (e) {
    e.fileName = file; // This was never used
    log(); // These show in a terminal console but not a debug console / gives the console space
    warn(new SyntaxError(`file ${file} was incorrectly setup`));
    log();
    process.exit(); // This terminates the bot
}})(file)
}
```

## Proposed

```js
try {
    // [...]
} catch (e) {
    e.fileName = file; // Adds the filename to the second [2/3] error message
    log();
    warn(e); // The error message from the broken command is sent to the console
    warn("SyntaxError:", `file ${file} was incorrectly setup so it was not loaded`);
    log(); // The process continues, skipping the failed command(s)
}
```